### PR TITLE
listViewのitemをタップした際にメモを更新できるようにロジックを修正

### DIFF
--- a/SimpleMemo/app/src/main/java/com/example/tominaga/simplememo/MemoDetailFragment.kt
+++ b/SimpleMemo/app/src/main/java/com/example/tominaga/simplememo/MemoDetailFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
+import android.widget.TextView
 
 /**
  * Created by tominaga on 2017/11/25.
@@ -13,10 +14,17 @@ import android.widget.EditText
 class MemoDetailFragment: Fragment() {
 
     var memoDetailView: View? = null
+    var position: Int = -1
 
     override fun onCreateView(inflater: LayoutInflater?, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)
         memoDetailView = inflater?.inflate(R.layout.memo_detail_fragment, container, false)
+        // bundle（更新情報）がある場合は情報をセット
+        if(arguments != null){
+            memoDetailView?.findViewById<EditText>(R.id.edit_text)?.setText(arguments.getString(MainActivity.updateMemoKey), TextView.BufferType.NORMAL)
+            position = arguments.getInt(MainActivity.updateMemoPositionKey)
+
+        }
         return memoDetailView
     }
 
@@ -25,4 +33,10 @@ class MemoDetailFragment: Fragment() {
         val edit = memoDetailView?.findViewById<EditText>(R.id.edit_text)
         return edit?.text.toString()
     }
+
+    // 更新するメモのpositionを返す
+    fun getMemoPosition() : Int {
+        return position
+    }
+
 }


### PR DESCRIPTION
**対応したこと**

- listViewのItemタップ時にFragmentの作成画面の呼び出し
- タップしたメモ情報をEditTextにセット
- アクションボタンで保存時に更新だった場合はcreateではなくupdateする

**他にやったほうが良さそうなこと**
- バックボタンでアプリ終了ではなくFragmentを閉じるようにする